### PR TITLE
fix colors_name empty issue

### DIFF
--- a/colors/gruvdark-light.lua
+++ b/colors/gruvdark-light.lua
@@ -1,2 +1,1 @@
-vim.g.colors_name = "gruvdark-light"
 require("gruvdark").load("gruvdark_light")

--- a/colors/gruvdark.lua
+++ b/colors/gruvdark.lua
@@ -1,2 +1,1 @@
-vim.g.colors_name = "gruvdark"
 require("gruvdark").load("gruvdark")

--- a/lua/gruvdark/init.lua
+++ b/lua/gruvdark/init.lua
@@ -9,6 +9,7 @@ M.load = function(palette_name, opts)
    opts = opts or M.opts or {}
 
    vim.cmd("highlight clear")
+   vim.g.colors_name = palette_name
    if vim.fn.exists("syntax_on") == 1 then
       vim.cmd("syntax reset")
    end


### PR DESCRIPTION
Ensure colors_name is set after 'highlight clear', since it resets vim.g.colors_name.